### PR TITLE
Fix running tests multiple times within the same process.

### DIFF
--- a/test/clj_live_reload/core_test.clj
+++ b/test/clj_live_reload/core_test.clj
@@ -10,6 +10,8 @@
 (deftest clj-live-reload
   (with-redefs [jetty/send! (fn [_ msg] (reset! sent-string msg))]
 
+    (reset! sent-string nil)
+
     (testing "ignores a non-hello message"
       ((ws-handler :on-text) :ws "{}")
       (is (nil? @sent-string)))


### PR DESCRIPTION
When running the tests within CIDER, I can only run the tests once before they begin to fail. The atom `sent-string` will still have the result from the final test and will not be nil.